### PR TITLE
feat: implement subscription-based feature restrictions

### DIFF
--- a/src/app/analysis/page.tsx
+++ b/src/app/analysis/page.tsx
@@ -4,7 +4,6 @@ import { Header } from '@/components/header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { BarChart3, TrendingUp, Users, DollarSign, Lock } from 'lucide-react'
-// import { getUserSubscription, hasAccessToFeature, getRequiredPlanForFeature } from '@/lib/subscription'
 import Link from 'next/link'
 
 export default async function AnalysisPage() {
@@ -14,8 +13,10 @@ export default async function AnalysisPage() {
     redirect('/sign-in')
   }
 
-  // Check if organization has analysis access permission
-  const hasAccess = await has({ permission: "org:analysis:access" })
+  // Check if organization has business_starter plan or higher
+  const hasAccess = has({ plan: 'business_starter' }) || 
+                   has({ plan: 'business_standard' }) || 
+                   has({ plan: 'enterprise' })
 
   return (
     <div className="min-h-screen bg-white">

--- a/src/app/audit/page.tsx
+++ b/src/app/audit/page.tsx
@@ -4,7 +4,6 @@ import { Header } from '@/components/header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Shield, AlertTriangle, CheckCircle, XCircle, Clock, Lock } from 'lucide-react'
-// import { getUserSubscription, hasAccessToFeature, getRequiredPlanForFeature } from '@/lib/subscription'
 import Link from 'next/link'
 
 export default async function AuditPage() {
@@ -14,8 +13,9 @@ export default async function AuditPage() {
     redirect('/sign-in')
   }
 
-  // Check if organization has audit access permission
-  const hasAccess = await has({ permission: "org:audit:access" })
+  // Check if organization has business_standard plan or higher
+  const hasAccess = has({ plan: 'business_standard' }) || 
+                   has({ plan: 'enterprise' })
 
   if (!hasAccess) {
     return (

--- a/src/components/dashboard-content.tsx
+++ b/src/components/dashboard-content.tsx
@@ -5,7 +5,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import { Building2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
 
 export function DashboardContent() {
   const { organization, isLoaded } = useOrganization()
@@ -104,22 +103,13 @@ interface Organization {
 
 function OrganizationDashboard({ organization }: { organization: Organization }) {
   const { has } = useAuth()
-  const [hasAnalysis, setHasAnalysis] = useState(false)
-  const [hasAudit, setHasAudit] = useState(false)
-
-  useEffect(() => {
-    const checkPermissions = async () => {
-      if (!has) return
-      
-      const analysisAccess = await has({ permission: "org:analysis:access" })
-      const auditAccess = await has({ permission: "org:audit:access" })
-      
-      setHasAnalysis(analysisAccess || false)
-      setHasAudit(auditAccess || false)
-    }
-    
-    checkPermissions()
-  }, [has])
+  
+  // Check plans using Clerk Billing
+  const hasAnalysis = has({ plan: 'business_starter' }) || 
+                     has({ plan: 'business_standard' }) || 
+                     has({ plan: 'enterprise' })
+  const hasAudit = has({ plan: 'business_standard' }) || 
+                  has({ plan: 'enterprise' })
 
   return (
     <div className="container mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary
- Replace custom permission system with Clerk Billing plan checks
- Simplify feature access control using built-in Clerk Billing functionality
- Remove complex permission-based logic in favor of plan-based restrictions

## Changes Made

### Feature Access Control
- **Analysis page**: Now requires `business_starter`, `business_standard`, or `enterprise` plan
- **Audit page**: Now requires `business_standard` or `enterprise` plan
- **Dashboard**: Feature cards visibility based on subscription plans

### Code Improvements
- Remove custom permission checks (`org:analysis:access`, `org:audit:access`)
- Replace with Clerk Billing's native `has({ plan: 'plan_name' })` checks
- Simplify dashboard component by removing async permission checking logic
- Clean up imports and unused code

### Technical Details
- Uses OR conditions for multiple plan checks: `has({ plan: 'business_starter' }) || has({ plan: 'business_standard' }) || has({ plan: 'enterprise' })`
- Leverages Clerk Billing's built-in subscription management
- Maintains same user experience with improved maintainability

## Test Plan
- [ ] Verify analysis page access with different subscription plans
- [ ] Verify audit page access restrictions
- [ ] Test dashboard feature card visibility
- [ ] Ensure proper redirect to pricing page for blocked features

🤖 Generated with [Claude Code](https://claude.ai/code)